### PR TITLE
fix: remove unused AirportIcon import to resolve build error

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTheme } from './ThemeProvider'
 import ThemeToggle from './ThemeToggle'
-import AirportIcon from './AirportIcon'
 
 export default function Header() {
   const { resolvedTheme } = useTheme()


### PR DESCRIPTION
Fixes #4

Removed unused `AirportIcon` import from `Header.tsx` that was causing TypeScript ESLint error:

```
7:8  Error: 'AirportIcon' is defined but never used.  @typescript-eslint/no-unused-vars
```

🤖 Generated with [Claude Code](https://claude.ai/code)