### PR TITLE
chore: fix lint for Worker (no-undef + unused args)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,9 @@ export default [
     rules: {
       ...js.configs.recommended.rules,
       ...typescript.configs.recommended.rules,
-      '@typescript-eslint/no-unused-vars': 'error',
+      // Base no-undef misfires on TS type-only names like Fetcher
+      'no-undef': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-non-null-assertion': 'error'

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,7 +7,7 @@ interface Env {
 }
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url)
     const isHTML = url.pathname === '/' || url.pathname.endsWith('.html')
 


### PR DESCRIPTION
Fixes failing CI lints after merge by disabling base no-undef for TS and removing unused ctx param from Worker fetch signature.