### PR TITLE
refactor: remove status indicator and currently label from homepage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,12 +67,6 @@ document.addEventListener('DOMContentLoaded', () => {
       <div class="page-container">
         <main class="hero-section">
           <div class="hero-content">
-            <!-- Status indicator -->
-            <div class="status-indicator">
-              <span class="status-dot"></span>
-              <span>Available for opportunities</span>
-            </div>
-
             <!-- Name -->
             <h1 class="hero-name">
               <span>RYAN CRUZ</span>
@@ -80,7 +74,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
             <!-- Split flap subtitle -->
             <div class="hero-subtitle">
-              <span class="subtitle-label">Currently</span>
               <div class="split-flap-wrapper">
                 <hotfx-split-flap>CYBERSECURITY ENGINEER</hotfx-split-flap>
               </div>

--- a/src/style.css
+++ b/src/style.css
@@ -197,35 +197,6 @@ body {
 }
 
 /* ============================================
-   Status Indicator
-   ============================================ */
-.status-indicator {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  color: var(--text-muted);
-  margin-bottom: 1rem;
-}
-
-.status-dot {
-  width: 6px;
-  height: 6px;
-  background: var(--green);
-  border-radius: 50%;
-  animation: pulse-glow 2s ease-in-out infinite;
-  box-shadow: 0 0 8px var(--green);
-}
-
-@keyframes pulse-glow {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.6; transform: scale(0.9); }
-}
-
-/* ============================================
    Name / Title
    ============================================ */
 .hero-name {
@@ -257,14 +228,6 @@ body {
   align-items: center;
   gap: 0.75rem;
   margin-top: 1rem;
-}
-
-.subtitle-label {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  color: var(--amber-dim);
 }
 
 /* Split flap wrapper with board styling */
@@ -429,10 +392,6 @@ hotfx-split-flap::part(divider) {
   }
 
   .page-container::after {
-    animation: none;
-  }
-
-  .status-dot {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- Removed the "Available for opportunities" status indicator section
- Removed the "Currently" label from the subtitle area

This simplifies the hero section layout on the homepage.

## Changes
- Modified `src/main.ts` to remove status indicator div and subtitle label